### PR TITLE
Add interactive category chart selection to filter transactions

### DIFF
--- a/transact-app/src/App.tsx
+++ b/transact-app/src/App.tsx
@@ -24,6 +24,7 @@ export default function App() {
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [loading, setLoading] = useState(false);
   const [loadedFiles, setLoadedFiles] = useState<string[]>([]);
+  const [selectedBar, setSelectedBar] = useState<{ month: string; category: string } | null>(null);
 
   async function handleFiles(files: File[]) {
     setLoading(true);
@@ -36,7 +37,7 @@ export default function App() {
     }
   }
 
-  function reset() { setTransactions([]); setLoadedFiles([]); }
+  function reset() { setTransactions([]); setLoadedFiles([]); setSelectedBar(null); }
 
   const monthlyData   = getMonthlyCategorySpend(transactions);
   const allCategories = getAllCategories(monthlyData);
@@ -47,6 +48,18 @@ export default function App() {
   const recurring     = getRecurringMerchants(transactions);
   const stats         = getSummaryStats(transactions, monthlyData);
   const hasData       = transactions.length > 0;
+  const otherCategories = allCategories.filter((cat) => !chartCategories.includes(cat));
+  const chartFilter = selectedBar ? {
+    month: selectedBar.month,
+    categories: selectedBar.category === 'Other' ? otherCategories : [selectedBar.category],
+    label: `${fmtMonthLong(selectedBar.month)} · ${selectedBar.category}`,
+  } : null;
+
+  function handleBarSelect(next: { month: string; category: string }) {
+    setSelectedBar((prev) => (
+      prev && prev.month === next.month && prev.category === next.category ? null : next
+    ));
+  }
 
   return (
     <div className="min-h-screen bg-slate-50">
@@ -110,7 +123,12 @@ export default function App() {
               <SectionLabel>Category Detail</SectionLabel>
               <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
                 <div className="lg:col-span-2">
-                  <CategoryChart data={chartData} categories={chartCategories} />
+                  <CategoryChart
+                    data={chartData}
+                    categories={chartCategories}
+                    selectedBar={selectedBar}
+                    onBarSelect={handleBarSelect}
+                  />
                 </div>
                 <div>
                   <TopMerchants data={topMerchants} />
@@ -129,7 +147,11 @@ export default function App() {
             {/* Transactions */}
             <section>
               <SectionLabel>Transactions</SectionLabel>
-              <TransactionTable transactions={transactions} />
+              <TransactionTable
+                transactions={transactions}
+                chartFilter={chartFilter}
+                onClearChartFilter={() => setSelectedBar(null)}
+              />
             </section>
           </>
         )}
@@ -146,4 +168,9 @@ export default function App() {
 
 function SectionLabel({ children }: { children: React.ReactNode }) {
   return <h2 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-3">{children}</h2>;
+}
+
+function fmtMonthLong(m: string) {
+  const [y, mo] = m.split('-');
+  return new Date(Number(y), Number(mo) - 1).toLocaleString('en-US', { month: 'short', year: 'numeric' });
 }

--- a/transact-app/src/components/CategoryChart.tsx
+++ b/transact-app/src/components/CategoryChart.tsx
@@ -37,6 +37,8 @@ export function catColor(cat: string, idx: number): string {
 interface Props {
   data: MonthlyCategorySpend[];
   categories: string[];
+  selectedBar?: { month: string; category: string } | null;
+  onBarSelect?: (selection: { month: string; category: string }) => void;
 }
 
 function fmtMonth(m: string) {
@@ -48,13 +50,11 @@ function fmtDollar(v: number) {
   return `$${v.toLocaleString('en-US', { maximumFractionDigits: 0 })}`;
 }
 
-export default function CategoryChart({ data, categories }: Props) {
+export default function CategoryChart({ data, categories, selectedBar, onBarSelect }: Props) {
   const [hidden, setHidden] = useState<Set<string>>(new Set());
 
   const toggle = (cat: string) =>
     setHidden((prev) => { const n = new Set(prev); n.has(cat) ? n.delete(cat) : n.add(cat); return n; });
-
-  const display = data.map((d) => ({ ...d, month: fmtMonth(d.month) }));
 
   // Defined as a stable render prop so Recharts doesn't remount it
   const renderTooltip = ({ active, payload, label }: any) => {
@@ -64,7 +64,7 @@ export default function CategoryChart({ data, categories }: Props) {
     const total = visible.reduce((s, p) => s + Number(p.value), 0);
     return (
       <div className="bg-white border border-slate-200 rounded-xl shadow-lg p-3 text-xs min-w-40">
-        <p className="font-semibold text-slate-600 mb-2">{label}</p>
+        <p className="font-semibold text-slate-600 mb-2">{fmtMonth(label)}</p>
         {visible.map((p, i) => (
           <div key={i} className="flex items-center justify-between gap-4 py-0.5">
             <span className="flex items-center gap-1.5 text-slate-600">
@@ -122,9 +122,15 @@ export default function CategoryChart({ data, categories }: Props) {
       </div>
 
       <ResponsiveContainer width="100%" height={340}>
-        <BarChart data={display} margin={{ top: 4, right: 16, left: 8, bottom: 4 }}>
+        <BarChart data={data} margin={{ top: 4, right: 16, left: 8, bottom: 4 }}>
           <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" vertical={false} />
-          <XAxis dataKey="month" tick={{ fontSize: 12 }} axisLine={false} tickLine={false} />
+          <XAxis
+            dataKey="month"
+            tick={{ fontSize: 12 }}
+            tickFormatter={fmtMonth}
+            axisLine={false}
+            tickLine={false}
+          />
           <YAxis tickFormatter={fmtDollar} tick={{ fontSize: 11 }} width={68} axisLine={false} tickLine={false} />
           <Tooltip
             content={renderTooltip}
@@ -140,8 +146,20 @@ export default function CategoryChart({ data, categories }: Props) {
               hide={hidden.has(cat)}
               fill={catColor(cat, i)}
               radius={i === categories.length - 1 ? [3, 3, 0, 0] : [0, 0, 0, 0]}
+              onClick={(_, index) => onBarSelect?.({ month: data[index].month, category: cat })}
             >
-              {display.map((_, j) => <Cell key={j} fill={catColor(cat, i)} />)}
+              {data.map((row, j) => {
+                const isSelected = selectedBar?.month === row.month && selectedBar.category === cat;
+                const hasSelection = Boolean(selectedBar);
+                return (
+                  <Cell
+                    key={j}
+                    fill={catColor(cat, i)}
+                    fillOpacity={hasSelection && !isSelected ? 0.35 : 1}
+                    cursor="pointer"
+                  />
+                );
+              })}
             </Bar>
           ))}
         </BarChart>

--- a/transact-app/src/components/TransactionTable.tsx
+++ b/transact-app/src/components/TransactionTable.tsx
@@ -1,15 +1,25 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { Transaction } from '../types';
 import { CATEGORY_COLORS } from './CategoryChart';
 import { cleanMerchantDisplay } from '../lib/categories';
 
 interface Props {
   transactions: Transaction[];
+  chartFilter?: {
+    month: string;
+    categories: string[];
+    label: string;
+  } | null;
+  onClearChartFilter?: () => void;
 }
 
 const PAGE_SIZE = 50;
 
-export default function TransactionTable({ transactions }: Props) {
+function monthKey(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+}
+
+export default function TransactionTable({ transactions, chartFilter, onClearChartFilter }: Props) {
   const [page, setPage] = useState(0);
   const [search, setSearch] = useState('');
   const [category, setCategory] = useState('');
@@ -18,6 +28,9 @@ export default function TransactionTable({ transactions }: Props) {
   const categories = Array.from(new Set(expenses.map((t) => t.category))).sort();
 
   const filtered = expenses
+    .filter((t) => !chartFilter || (
+      monthKey(t.date) === chartFilter.month && chartFilter.categories.includes(t.category)
+    ))
     .filter((t) => !search || t.description.toLowerCase().includes(search.toLowerCase()))
     .filter((t) => !category || t.category === category)
     .sort((a, b) => b.date.getTime() - a.date.getTime());
@@ -27,6 +40,7 @@ export default function TransactionTable({ transactions }: Props) {
 
   function handleSearch(v: string) { setSearch(v); setPage(0); }
   function handleCategory(v: string) { setCategory(v); setPage(0); }
+  useEffect(() => setPage(0), [chartFilter?.month, chartFilter?.label]);
 
   const catColor = (cat: string) => CATEGORY_COLORS[cat] ?? '#94a3b8';
 
@@ -57,6 +71,18 @@ export default function TransactionTable({ transactions }: Props) {
           <option value="">All categories</option>
           {categories.map((c) => <option key={c} value={c}>{c}</option>)}
         </select>
+        {chartFilter && (
+          <span className="inline-flex items-center gap-1.5 text-xs bg-blue-50 text-blue-700 border border-blue-200 px-2.5 py-1 rounded-full">
+            Chart filter: {chartFilter.label}
+            <button
+              onClick={onClearChartFilter}
+              className="text-blue-500 hover:text-blue-700"
+              title="Clear chart filter"
+            >
+              ✕
+            </button>
+          </span>
+        )}
         <span className="text-xs text-slate-400 ml-auto">{filtered.length} transactions</span>
       </div>
 


### PR DESCRIPTION
### Motivation
- Make the category-by-month bar chart actionable so users can click a stacked segment and drill into the transactions that contributed to that bar segment.
- Surface an explicit, reversible chart-driven filter in the transactions list so users can quickly explore month+category slices.
- Preserve existing chart/legend interactions while adding selection visual feedback and support for the aggregated `Other` bucket.

### Description
- Added selection state in `App` (`selectedBar`) and a handler `handleBarSelect` to toggle a `{month, category}` selection and produce a `chartFilter` object consumed by the table.
- Enhanced `CategoryChart` to accept `selectedBar` and `onBarSelect` props, to call `onBarSelect` when a stacked bar segment is clicked, and to dim non-selected segments via `Cell` `fillOpacity` while keeping a pointer cursor.
- Updated `TransactionTable` to accept a `chartFilter`, apply month+category filtering before existing search/category filters, reset pagination when the chart filter changes, and display a removable filter chip; mapped the `Other` chart bucket to the set of hidden categories for filtering.
- Small UX tweaks include formatting X-axis ticks with `tickFormatter`, using `fmtMonth`/`fmtMonthLong` for labels, and clearing `selectedBar` on global reset.

### Testing
- Attempted `cd transact-app && npm run build` which failed because there is no `package.json` in `transact-app` in this environment (build failed).
- No other automated test suites were available or run as part of this change in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0380630248332b2c35e31e83e2d1d)