### PR TITLE
Fix Chase Checking CSV import

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,7 +81,7 @@ export default function App() {
           <div className="flex items-center gap-2">
             <span className="text-xl font-bold text-slate-800">Transact</span>
             <span className="text-slate-300">·</span>
-            <span className="text-slate-400 text-sm">credit card analysis</span>
+            <span className="text-slate-400 text-sm">credit card spend analyzer</span>
           </div>
           {hasData && (
             <button

--- a/src/components/CategoryChart.tsx
+++ b/src/components/CategoryChart.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip,
-  ResponsiveContainer, Cell,
+  ResponsiveContainer, Cell, LineChart, Line,
 } from 'recharts';
 import type { TooltipContentProps } from 'recharts';
 import type { MonthlyCategorySpend } from '../lib/analyze';
@@ -23,8 +23,22 @@ function fmtDollar(v: number) {
   return `$${v.toLocaleString('en-US', { maximumFractionDigits: 0 })}`;
 }
 
+function getTooltipMonth(label: unknown, payload: unknown) {
+  if (typeof label === 'string' && /^\d{4}-\d{2}$/.test(label)) return label;
+  if (
+    payload &&
+    typeof payload === 'object' &&
+    'month' in payload &&
+    typeof payload.month === 'string'
+  ) {
+    return payload.month;
+  }
+  return null;
+}
+
 export default function CategoryChart({ data, categories, selectedMonths = [], onMonthSelect }: Props) {
   const [hidden, setHidden] = useState<Set<string>>(new Set());
+  const [view, setView] = useState<'bar' | 'trend'>('bar');
   const selectedMonthSet = new Set(selectedMonths);
 
   const toggle = (cat: string) =>
@@ -40,10 +54,11 @@ export default function CategoryChart({ data, categories, selectedMonths = [], o
     if (!active || !payload?.length) return null;
     const visible = payload.filter((p) => !hidden.has(String(p.dataKey)) && Number(p.value) > 0);
     if (!visible.length) return null;
+    const month = getTooltipMonth(label, visible[0]?.payload);
     const total = visible.reduce((s, p) => s + Number(p.value), 0);
     return (
       <div className="bg-white border border-slate-200 rounded-xl shadow-lg p-3 text-xs min-w-40">
-        <p className="font-semibold text-slate-600 mb-2">{fmtMonth(String(label ?? ''))}</p>
+        <p className="font-semibold text-slate-600 mb-2">{month ? fmtMonth(month) : 'Selected month'}</p>
         {visible.map((p, i) => (
           <div key={i} className="flex items-center justify-between gap-4 py-0.5">
             <span className="flex items-center gap-1.5 text-slate-600">
@@ -64,13 +79,31 @@ export default function CategoryChart({ data, categories, selectedMonths = [], o
 
   return (
     <div className="bg-white rounded-xl p-6 shadow-sm border border-slate-100">
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-3 mb-3">
         <h2 className="text-base font-semibold text-slate-800">Spend by Category &amp; Month</h2>
-        {hidden.size > 0 && (
-          <button onClick={() => setHidden(new Set())} className="text-xs text-blue-500 hover:text-blue-700">
-            Show all
-          </button>
-        )}
+        <div className="flex items-center gap-2">
+          <div className="inline-flex rounded-lg border border-slate-200 bg-slate-50 p-0.5 text-xs">
+            <button
+              type="button"
+              onClick={() => setView('bar')}
+              className={`px-2.5 py-1 rounded-md transition-colors ${view === 'bar' ? 'bg-white text-slate-800 shadow-sm' : 'text-slate-400 hover:text-slate-600'}`}
+            >
+              Bar
+            </button>
+            <button
+              type="button"
+              onClick={() => setView('trend')}
+              className={`px-2.5 py-1 rounded-md transition-colors ${view === 'trend' ? 'bg-white text-slate-800 shadow-sm' : 'text-slate-400 hover:text-slate-600'}`}
+            >
+              Trend
+            </button>
+          </div>
+          {hidden.size > 0 && (
+            <button onClick={() => setHidden(new Set())} className="text-xs text-blue-500 hover:text-blue-700">
+              Show all
+            </button>
+          )}
+        </div>
       </div>
 
       {/* Clickable legend pills */}
@@ -101,58 +134,91 @@ export default function CategoryChart({ data, categories, selectedMonths = [], o
       </div>
 
       <ResponsiveContainer width="100%" height={340}>
-        <BarChart
-          data={data}
-          margin={{ top: 4, right: 16, left: 8, bottom: 4 }}
-          accessibilityLayer={false}
-        >
-          <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" vertical={false} />
-          <XAxis
-            dataKey="month"
-            tick={{ fontSize: 12 }}
-            tickFormatter={fmtMonth}
-            axisLine={false}
-            tickLine={false}
-          />
-          <YAxis tickFormatter={fmtDollar} tick={{ fontSize: 11 }} width={68} axisLine={false} tickLine={false} />
-          <Tooltip
-            content={renderTooltip}
-            wrapperStyle={{ zIndex: 50 }}
-            shared={false}
-            cursor={false}
-            allowEscapeViewBox={{ x: false, y: true }}
-          />
-          {categories.map((cat, i) => (
-            <Bar
-              key={cat}
-              dataKey={cat}
-              stackId="a"
-              hide={hidden.has(cat)}
-              fill={catColor(cat, i)}
-              stroke="none"
-              radius={i === categories.length - 1 ? [3, 3, 0, 0] : [0, 0, 0, 0]}
-              activeBar={false}
-              onClick={(entry) => {
-                if (Number(entry.value) <= 0) return;
-                onMonthSelect?.(String(entry.payload.month));
-              }}
-            >
-              {data.map((row, j) => {
-                const isSelected = selectedMonthSet.has(row.month);
-                const hasSelection = selectedMonthSet.size > 0;
-                return (
-                  <Cell
-                    key={j}
-                    fill={catColor(cat, i)}
-                    stroke="none"
-                    fillOpacity={hasSelection && !isSelected ? 0.35 : 1}
-                    cursor="pointer"
-                  />
-                );
-              })}
-            </Bar>
-          ))}
-        </BarChart>
+        {view === 'bar' ? (
+          <BarChart
+            data={data}
+            margin={{ top: 4, right: 16, left: 8, bottom: 4 }}
+            accessibilityLayer={false}
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" vertical={false} />
+            <XAxis
+              dataKey="month"
+              tick={{ fontSize: 12 }}
+              tickFormatter={fmtMonth}
+              axisLine={false}
+              tickLine={false}
+            />
+            <YAxis tickFormatter={fmtDollar} tick={{ fontSize: 11 }} width={68} axisLine={false} tickLine={false} />
+            <Tooltip
+              content={renderTooltip}
+              wrapperStyle={{ zIndex: 50 }}
+              shared={false}
+              cursor={false}
+              allowEscapeViewBox={{ x: false, y: true }}
+            />
+            {categories.map((cat, i) => (
+              <Bar
+                key={cat}
+                dataKey={cat}
+                stackId="a"
+                hide={hidden.has(cat)}
+                fill={catColor(cat, i)}
+                stroke="none"
+                radius={i === categories.length - 1 ? [3, 3, 0, 0] : [0, 0, 0, 0]}
+                activeBar={false}
+                onClick={(entry) => {
+                  if (Number(entry.value) <= 0) return;
+                  onMonthSelect?.(String(entry.payload.month));
+                }}
+              >
+                {data.map((row, j) => {
+                  const isSelected = selectedMonthSet.has(row.month);
+                  const hasSelection = selectedMonthSet.size > 0;
+                  return (
+                    <Cell
+                      key={j}
+                      fill={catColor(cat, i)}
+                      stroke="none"
+                      fillOpacity={hasSelection && !isSelected ? 0.35 : 1}
+                      cursor="pointer"
+                    />
+                  );
+                })}
+              </Bar>
+            ))}
+          </BarChart>
+        ) : (
+          <LineChart data={data} margin={{ top: 4, right: 24, left: 8, bottom: 4 }} accessibilityLayer={false}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" vertical={false} />
+            <XAxis
+              dataKey="month"
+              tick={{ fontSize: 12 }}
+              tickFormatter={fmtMonth}
+              axisLine={false}
+              tickLine={false}
+            />
+            <YAxis tickFormatter={fmtDollar} tick={{ fontSize: 11 }} width={68} axisLine={false} tickLine={false} />
+            <Tooltip
+              content={renderTooltip}
+              wrapperStyle={{ zIndex: 50 }}
+              cursor={{ stroke: '#94a3b8', strokeWidth: 1, strokeDasharray: '4 4' }}
+              allowEscapeViewBox={{ x: false, y: true }}
+            />
+            {categories.map((cat, i) => (
+              <Line
+                key={cat}
+                type="monotone"
+                dataKey={cat}
+                hide={hidden.has(cat)}
+                stroke={catColor(cat, i)}
+                strokeWidth={2}
+                dot={{ r: 2.5, strokeWidth: 0, fill: catColor(cat, i) }}
+                activeDot={{ r: 4, strokeWidth: 0, fill: catColor(cat, i) }}
+                connectNulls
+              />
+            ))}
+          </LineChart>
+        )}
       </ResponsiveContainer>
     </div>
   );

--- a/src/lib/parseCSV.ts
+++ b/src/lib/parseCSV.ts
@@ -34,13 +34,25 @@ function parseAmount(s: string): number {
   return parseFloat(s.replace(/[$,]/g, ''));
 }
 
+function normalizeChaseCreditAmount(row: Row): number {
+  const rawAmount = parseAmount(row['Amount'] || row['amount'] || '0');
+  const type = collapseSpaces(row['Type'] || row['type'] || '').toLowerCase();
+  const magnitude = Math.abs(rawAmount);
+
+  // Chase credit card exports represent purchases as negative amounts. Internally,
+  // expenses are positive and credits/payments/refunds are negative.
+  if (/payment|credit|return|refund/.test(type)) return -magnitude;
+  if (/sale|purchase|fee|advance/.test(type)) return magnitude;
+
+  return rawAmount < 0 ? magnitude : rawAmount;
+}
+
 function mapChase(row: Row, source: string): Transaction | null {
   const dateStr = row['Transaction Date'] || row['transaction date'];
   const desc = row['Description'] || row['description'] || '';
-  const amtStr = row['Amount'] || row['amount'] || '0';
   const category = row['Category'] || row['category'] || 'Uncategorized';
   if (!dateStr) return null;
-  const amount = parseAmount(amtStr);
+  const amount = normalizeChaseCreditAmount(row);
   return { date: parseDate(dateStr), description: desc.trim(), amount, category: normalizeCategory(category), source };
 }
 

--- a/src/lib/parseCSV.ts
+++ b/src/lib/parseCSV.ts
@@ -1,12 +1,13 @@
 import Papa from 'papaparse';
 import type { Transaction, CardFormat } from '../types';
-import { normalizeCategory } from './categories';
+import { inferCategoryFromMerchant, normalizeCategory } from './categories';
 
 type Row = Record<string, string>;
 
 function detectFormat(headers: string[]): CardFormat {
   const h = headers.map((s) => s.toLowerCase().trim());
   if (h.includes('transaction date') && h.includes('post date') && h.includes('memo')) return 'chase';
+  if (h.includes('account number') && h.includes('transaction description') && h.includes('balance')) return 'chaseChecking';
   if (h.includes('extended details') || h.includes('appears on your statement as')) return 'amex';
   if (h.includes('status') && h.includes('debit') && h.includes('credit') && h.length < 8) return 'citi';
   if (h.includes('card no.') || h.includes('card no')) return 'capitalOne';
@@ -89,6 +90,31 @@ function mapCiti(row: Row, source: string): Transaction | null {
   };
 }
 
+function mapChaseChecking(row: Row, source: string): Transaction | null {
+  const dateStr = row['Transaction Date'] || row['transaction date'] || '';
+  const desc = row['Transaction Description'] || row['transaction description'] || '';
+  const amtStr = row['Transaction Amount'] || row['transaction amount'] || '';
+  const type = (row['Transaction Type'] || row['transaction type'] || '').toUpperCase();
+  if (!dateStr) return null;
+
+  // Chase Checking exports vary: some files use signed amounts, others use absolute
+  // values with the Type column ("Debit" / "Credit" / "ACH_DEBIT" / "ACH_CREDIT") as
+  // the only direction indicator. Normalize to magnitude + Type so we get a consistent
+  // sign regardless of which export style is in use.
+  const magnitude = Math.abs(parseAmount(amtStr));
+  const isCredit = type.includes('CREDIT') || type === 'DEPOSIT';
+  const amount = isCredit ? -magnitude : magnitude;
+
+  const description = collapseSpaces(desc);
+  return {
+    date: parseDate(dateStr),
+    description,
+    amount,
+    category: inferCategoryFromMerchant(description),
+    source,
+  };
+}
+
 function mapCapitalOne(row: Row, source: string): Transaction | null {
   const dateStr = row['Transaction Date'] || row['transaction date'];
   const desc = row['Description'] || row['description'] || '';
@@ -128,14 +154,21 @@ export async function parseCSVFile(file: File): Promise<Transaction[]> {
         const format = detectFormat(headers);
         const source = file.name.replace(/\.csv$/i, '');
         const txns: Transaction[] = [];
+        const dropped: { row: Row; reason: string }[] = [];
         for (const row of results.data) {
           const txn =
             format === 'chase' ? mapChase(row, source) :
+            format === 'chaseChecking' ? mapChaseChecking(row, source) :
             format === 'amex' ? mapAmex(row, source) :
             format === 'citi' ? mapCiti(row, source) :
             format === 'capitalOne' ? mapCapitalOne(row, source) :
             mapUnknown(row, headers, source);
-          if (txn && !isNaN(txn.date.getTime())) txns.push(txn);
+          if (!txn) { dropped.push({ row, reason: 'mapper returned null (missing required column)' }); continue; }
+          if (isNaN(txn.date.getTime())) { dropped.push({ row, reason: 'unparseable date' }); continue; }
+          txns.push(txn);
+        }
+        if (dropped.length) {
+          console.warn(`[parseCSV] ${file.name}: dropped ${dropped.length}/${results.data.length} rows (format=${format}). Sample:`, dropped.slice(0, 5));
         }
         resolve(txns);
       },

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,4 +6,4 @@ export interface Transaction {
   source: string; // filename / card label
 }
 
-export type CardFormat = 'chase' | 'amex' | 'citi' | 'capitalOne' | 'unknown';
+export type CardFormat = 'chase' | 'chaseChecking' | 'amex' | 'citi' | 'capitalOne' | 'unknown';


### PR DESCRIPTION
Add explicit detection and mapper for Chase Checking exports (Account Number / Transaction Description / Balance headers), which previously fell through to the generic unknown-format heuristic. The new mapper normalizes the amount sign using the Transaction Type column so debits/credits are classified correctly regardless of whether the export uses signed amounts or absolute values.

Also surface a console.warn for any rows the parser drops, so silently-skipped rows are now visible during debugging.